### PR TITLE
.icon-bar replaced by navbar-toggler-icon

### DIFF
--- a/tpl/nav-menu.tpl
+++ b/tpl/nav-menu.tpl
@@ -8,9 +8,7 @@
 
                 <div class="navbar-header">
                     <button data-target=".navbar-collapse" data-toggle="collapse" class="navbar-toggler" type="button">
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
+						<span class="navbar-toggler-icon"></span>
                     </button>
                     <a href="<{$xoops_url}>" class="navbar-brand xlogo" title="<{$xoops_sitename}>">
                         <img src="<{$xoops_imageurl}>images/logo.png" alt="<{$xoops_sitename}>">


### PR DESCRIPTION
The class "icon-bar" needs to be replaced to "navbar-toggler-icon" in order to toggle menu work on small devices.
Reference:
(1) https://github.com/iamphill/Bootstrap-Offcanvas/issues/30

(2) http://v4-alpha.getbootstrap.com/components/navbar/