### PR TITLE
Fix rendering caption required icon

### DIFF
--- a/css/xoops.css
+++ b/css/xoops.css
@@ -54,6 +54,14 @@ img.right {
 }
 
 /* For required elements in XOOPS form */
+/* For Xoops 2.5.11 - Used in XoopsFormRenderer for Bootstrap and Bootstrap based theme templates */
+.xo-caption-required {
+    background-color: inherit;
+    padding-left: 2px;
+    color: #ff0000;
+}
+
+/* Used in XoopsFormRendererLegacy */
 .xoops-form-element-caption .caption-marker {
     display: none;
 }


### PR DESCRIPTION
This fix requires the corresponding fixes in XoopsCore25 and xbootstrap5.
See pull request for XoopsCore25 for full details.